### PR TITLE
Explicit strict_supports in tests

### DIFF
--- a/tests/test_octodns_provider_dyn.py
+++ b/tests/test_octodns_provider_dyn.py
@@ -378,7 +378,9 @@ class TestDynProvider(TestCase):
 
     @patch('dyn.core.SessionEngine.execute')
     def test_sync(self, execute_mock):
-        provider = DynProvider('test', 'cust', 'user', 'pass')
+        provider = DynProvider(
+            'test', 'cust', 'user', 'pass', strict_supports=False
+        )
 
         # Test Zone create
         execute_mock.side_effect = [


### PR DESCRIPTION
As of https://github.com/octodns/octodns/pull/957 we'll need t be explicit in our tests around the expectations of `Provider.strict_supports`. This PR is in preparation of that change. 

/cc https://github.com/octodns/octodns/pull/957